### PR TITLE
Reunify master into main — stray CHANGELOG.md; main is the single default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-06-30
+
+### Added
+- Initial release of Apte Sanskrit–English Dictionary dataset and utilities.
+- Full dictionary data with markup and structured metadata.
+- CHANGELOG tracking for future releases.
+- Pre-commit configuration for automated validation.
+- Dependabot configuration for GitHub Actions updates.
+
+### Changed
+- Migrated to full CC-BY-SA-4.0 legalcode for dictionary data enabling GitHub license auto-detection.
+
+### Fixed
+- Improved change-file validator with smarter logic and per-repo exclusions.
+
+### Security
+- No security updates in this release.


### PR DESCRIPTION
Same dual-branch trap as [MWS PR #224](https://github.com/sanskrit-lexicon/MWS/pull/224) ([Uprava FINDINGS §25](https://github.com/gasyoun/Uprava/blob/main/FINDINGS.md)): one stray commit (`docs: add CHANGELOG.md`, 30-06-2026) landed on non-default `master` while all work (landing page, Pages, markup fixer) lands on default `main`. Purely additive merge (1 file, 24 insertions), no conflicts; `master` is deleted after merge.

Session: Fable 5 (`claude-fable-5`), 03-07-2026, MG-authorized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)